### PR TITLE
Remove multiple gem dependencies

### DIFF
--- a/README.org
+++ b/README.org
@@ -46,14 +46,15 @@ buffer as an org-table, ready for processing by other code blocks.
 
 ** Prerequisites
 The ~fat_table~ gem depends on several libraries being available for building,
-mostly those concerned with accessing databases.  On an ubuntu system, the
+mostly those concerned with accessing databases. Postgresql is the default database
+ adapter, but the ~mysql2~ and ~sqlite3~ gems can also be used. On an ubuntu system, the
 following packages should be installed before you install the ~fat_table~ gem:
 
 - ruby-dev
 - build-essential
-- libsqlite3-dev
 - libpq-dev
-- libmysqlclient-dev
+- libsqlite3-dev (if using sqlite3)
+- libmysqlclient-dev (if using mysql)
 
 ** Installing the gem
 

--- a/fat_table.gemspec
+++ b/fat_table.gemspec
@@ -77,9 +77,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>3.0'
   spec.add_runtime_dependency 'fat_core', '>= 4.1'
-  spec.add_runtime_dependency 'mysql2'
   spec.add_runtime_dependency 'pg'
   spec.add_runtime_dependency 'rainbow'
   spec.add_runtime_dependency 'sequel'
-  spec.add_runtime_dependency 'sqlite3'
 end

--- a/md/README.md
+++ b/md/README.md
@@ -89,16 +89,17 @@ buffer as an org-table, ready for processing by other code blocks.
 
 ## Prerequisites
 
+** Prerequisites
 The `fat_table` gem depends on several libraries being available for building,
-mostly those concerned with accessing databases.  On an ubuntu system, the
-following packages should be installed before you install the `fat_table` gem:
+mostly those concerned with accessing databases. Postgresql is the default database
+ adapter, but the `mysql2` and `sqlite3` gems can also be used. On an ubuntu system, the
+following packages should be installed before you install the ~fat_table~ gem:
 
--   ruby-dev
--   build-essential
--   libsqlite3-dev
--   libpq-dev
--   libmysqlclient-dev
-
+- ruby-dev
+- build-essential
+- libpq-dev
+- libsqlite3-dev (if using sqlite3)
+- libmysqlclient-dev (if using mysql)
 
 <a id="orga19109b"></a>
 


### PR DESCRIPTION
Closes #4 

Removes explicit dependencies to mysql and sqlite database adapters, leaving postgres as the default and the other two as optional. This removes the requirement for installing all three simultaneously, so gem and package dependencies are looser.